### PR TITLE
[Minor UX] Store Selective state

### DIFF
--- a/template/filter.js
+++ b/template/filter.js
@@ -1,4 +1,6 @@
 (function () {
+    var selectiveStore = JSON.parse(window.localStorage.getItem('selective'));
+
     var $ = function (id) {
         return document.getElementById(id);
     };
@@ -8,18 +10,25 @@
         else el.classList.remove(className);
     };
     var selective = false;
+    if (selectiveStore && typeof selectiveStore === 'boolean') {
+        selective = selectiveStore;
+    }
     var setupSelective = function () {
         var btn = $('selective');
         reclass('selective', false, 'nodisplay');
-        function toggleSelective() {
-            selective = !selective;
+        function setBtnState() {
             reclass('provinces', selective, 'selective');
             reclass('selective', !selective, 'outline');
             btn.innerHTML = selective ? '&#x25BC; Tampilkan Semua Provinsi' : '&#x25B2; Hanya 7 Besar';
             btn.blur();
         }
+        function toggleSelective() {
+            selective = !selective;
+            window.localStorage.setItem('selective', selective);
+            setBtnState();
+        }
         btn.addEventListener('click', toggleSelective);
-        toggleSelective();
+        setBtnState();
     };
     var setupFilter = function () {
         reclass('search', false, 'nodisplay');


### PR DESCRIPTION
# Description
Propose this minor UX to:
Set selective filter option to localStorage, so user won't have to click twice after page refresh, instead retrieve from the prior state which the user has chosen.

## before:

![selective-filter-before](https://user-images.githubusercontent.com/10743728/82178755-f2c3e780-9906-11ea-9e2b-7724b7a0e824.gif)

## after:

![selective-filter-after](https://user-images.githubusercontent.com/10743728/82178766-f8b9c880-9906-11ea-8bac-ccbdef0a4fd4.gif)
